### PR TITLE
Potential fix for code scanning alert no. 23: SQL query built from user-controlled sources

### DIFF
--- a/validate_indexes.py
+++ b/validate_indexes.py
@@ -59,7 +59,7 @@ def check_database_indexes(db_path: str) -> None:
             for idx in sorted(existing_indexes):
                 # Ensure idx is a safe SQLite identifier (alphanumeric or underscore)
                 if not re.match(r"^\w+$", idx):
-                    continue  # or raise an error if you prefer
+                if not re.match(r'^[A-Za-z0-9_]+$', idx):
                 # Get index details
                 cursor.execute(f"PRAGMA index_info('{idx}')")
                 [row[2] for row in cursor.fetchall()]

--- a/validate_indexes.py
+++ b/validate_indexes.py
@@ -35,13 +35,11 @@ def check_database_indexes(db_path: str) -> None:
             cursor = conn.cursor()
 
             # Get all indexes on note_list table
-            cursor.execute(
-                """
+            cursor.execute("""
                 SELECT name FROM sqlite_master
                 WHERE type='index' AND tbl_name='note_list'
                 ORDER BY name
-            """
-            )
+            """)
 
             existing_indexes = [row[0] for row in cursor.fetchall()]
 
@@ -57,9 +55,10 @@ def check_database_indexes(db_path: str) -> None:
 
             # Show all existing indexes
             import re
+
             for idx in sorted(existing_indexes):
                 # Ensure idx is a safe SQLite identifier (alphanumeric or underscore)
-                if not re.match(r'^\w+$', idx):
+                if not re.match(r"^\w+$", idx):
                     continue  # or raise an error if you prefer
                 # Get index details
                 cursor.execute(f"PRAGMA index_info('{idx}')")
@@ -121,7 +120,8 @@ def main():
     """Main validation function"""
 
     # Check for notes database
-    base_dir = os.path.join(os.path.dirname(__file__), "user_data", "databases")
+    base_dir = os.path.join(os.path.dirname(
+        __file__), "user_data", "databases")
     notes_db = os.path.join(base_dir, "notes.db")
 
     if not os.path.exists(notes_db):

--- a/validate_indexes.py
+++ b/validate_indexes.py
@@ -56,7 +56,11 @@ def check_database_indexes(db_path: str) -> None:
                 pass
 
             # Show all existing indexes
+            import re
             for idx in sorted(existing_indexes):
+                # Ensure idx is a safe SQLite identifier (alphanumeric or underscore)
+                if not re.match(r'^\w+$', idx):
+                    continue  # or raise an error if you prefer
                 # Get index details
                 cursor.execute(f"PRAGMA index_info('{idx}')")
                 [row[2] for row in cursor.fetchall()]

--- a/validate_indexes.py
+++ b/validate_indexes.py
@@ -58,7 +58,6 @@ def check_database_indexes(db_path: str) -> None:
 
             for idx in sorted(existing_indexes):
                 # Ensure idx is a safe SQLite identifier (alphanumeric or underscore)
-                if not re.match(r"^\w+$", idx):
                 if not re.match(r'^[A-Za-z0-9_]+$', idx):
                 # Get index details
                 cursor.execute(f"PRAGMA index_info('{idx}')")


### PR DESCRIPTION
Potential fix for [https://github.com/dinoopitstudios/DinoAir/security/code-scanning/23](https://github.com/dinoopitstudios/DinoAir/security/code-scanning/23)

The best solution is to avoid directly interpolating possibly untrusted values into the SQL, even for PRAGMA statements. Since SQLite's Python API does not support parameter substitution for PRAGMA identifiers, the best alternative is to strictly validate or escape the index name before interpolating it. In this context, we can validate `idx` (the index name) against a whitelist (`expected_indexes`). Alternatively, we can use a regex that only allows typical identifier characters (alphanumeric, underscores), which is appropriate here since all expected index names match that pattern.

Change needed: Before interpolating `idx` into the `PRAGMA index_info(...)` statement, validate that `idx` matches the expected safe pattern (for example, only letters, digits, and underscores). If not, skip or raise an error.  
No new imports are needed, as Python's standard library `re` can be used.

Add a regular expression check above the interpolation and only execute the PRAGMA if the name passes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
