### PR TITLE
New

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -44,7 +44,8 @@ name = "test-coverage"
 name = "python"
 
   [analyzers.meta]
-  runtime_version = "3.x.x"
+  runtime_version = "3.11"
+  max_line_length = 100
 
 [[analyzers]]
 name = "secrets"
@@ -60,12 +61,3 @@ name = "ruff"
 
 [[transformers]]
 name = "prettier"
-
-[[transformers]]
-name = "yapf"
-
-[[transformers]]
-name = "autopep8"
-
-[[transformers]]
-name = "standardjs"

--- a/LINE_LENGTH_GUIDE.md
+++ b/LINE_LENGTH_GUIDE.md
@@ -6,22 +6,24 @@ Your project is now configured for **100 characters**, which is the modern Pytho
 
 ## 📏 **Line Length Standards Comparison**
 
-| Standard | Length | Used By | Pros | Cons |
-|----------|--------|---------|------|------|
-| **PEP 8 Classic** | 79 | Old Python projects | Maximum compatibility | Too restrictive for modern screens |
-| **Black Default** | 88 | Many modern projects | Good balance | Slightly cramped |
-| **Modern Standard** | 100 | Your project, Django, FastAPI | Practical for today's screens | May not fit on small terminals |
-| **Liberal** | 120+ | Some teams | Very spacious | Can encourage overly complex lines |
+| Standard            | Length | Used By                       | Pros                          | Cons                               |
+| ------------------- | ------ | ----------------------------- | ----------------------------- | ---------------------------------- |
+| **PEP 8 Classic**   | 79     | Old Python projects           | Maximum compatibility         | Too restrictive for modern screens |
+| **Black Default**   | 88     | Many modern projects          | Good balance                  | Slightly cramped                   |
+| **Modern Standard** | 100    | Your project, Django, FastAPI | Practical for today's screens | May not fit on small terminals     |
+| **Liberal**         | 120+   | Some teams                    | Very spacious                 | Can encourage overly complex lines |
 
 ## ✅ **Why 100 Characters is Recommended**
 
 ### **Modern Development Reality:**
+
 - **Screen sizes:** Most developers have wide monitors
 - **Code review tools:** GitHub, GitLab handle 100+ characters well
 - **IDE support:** Modern editors handle longer lines effectively
 - **Team productivity:** Less time spent on artificial line breaks
 
 ### **Popular Projects Using 100+ Characters:**
+
 - **Django:** 119 characters
 - **FastAPI:** 100 characters
 - **Pandas:** 100 characters
@@ -30,6 +32,7 @@ Your project is now configured for **100 characters**, which is the modern Pytho
 ## 🔧 **Current Project Configuration**
 
 ### **DeepSource (`.deepsource.toml`)**
+
 ```toml
 [[analyzers]]
 name = "python"
@@ -39,6 +42,7 @@ name = "python"
 ```
 
 ### **Black (`.pyproject.toml`)**
+
 ```toml
 [tool.black]
 line-length = 100
@@ -46,6 +50,7 @@ target-version = ['py312']
 ```
 
 ### **Ruff (`.pyproject.toml`)**
+
 ```toml
 [tool.ruff]
 line-length = 100
@@ -53,6 +58,7 @@ target-version = "py312"
 ```
 
 ### **Prettier (`.prettierrc.json`)**
+
 ```json
 {
   "printWidth": 100
@@ -62,6 +68,7 @@ target-version = "py312"
 ## 🚀 **Implementation Status**
 
 ### **✅ Fixed Issues:**
+
 1. **DeepSource Configuration:** Updated to use 100 characters instead of 79
 2. **Transformer Conflicts:** Removed conflicting formatters (yapf, autopep8)
 3. **Runtime Version:** Set to Python 3.11 to match your environment
@@ -70,12 +77,14 @@ target-version = "py312"
 ### **🔄 Before/After Comparison:**
 
 **Before (Causing Errors):**
+
 - DeepSource: 79 characters (default)
 - Black: 100 characters
 - Ruff: 100 characters
 - **Result:** Constant line length violations
 
 **After (Consistent):**
+
 - DeepSource: 100 characters ✅
 - Black: 100 characters ✅
 - Ruff: 100 characters ✅
@@ -84,6 +93,7 @@ target-version = "py312"
 ## 🛠️ **Alternative Configurations**
 
 ### **If You Want 88 Characters (Black Default):**
+
 ```toml
 # In pyproject.toml
 [tool.black]
@@ -98,6 +108,7 @@ max_line_length = 88
 ```
 
 ### **If You Must Use 79 Characters:**
+
 ```toml
 # In pyproject.toml
 [tool.black]
@@ -114,6 +125,7 @@ line-length = 79
 ### **When to Break Lines (Even with 100 character limit):**
 
 1. **Function signatures with many parameters:**
+
    ```python
    def complex_function(
        param1: str,
@@ -123,6 +135,7 @@ line-length = 79
    ```
 
 2. **Long import statements:**
+
    ```python
    from some.very.long.module.name import (
        first_function,
@@ -143,11 +156,13 @@ line-length = 79
 ### **Tools to Help:**
 
 1. **Black:** Automatically formats to 100 characters
+
    ```bash
    black .
    ```
 
 2. **Ruff:** Checks and fixes line length issues
+
    ```bash
    ruff check . --fix
    ```
@@ -171,12 +186,14 @@ Your DeepSource analysis should now show **significantly fewer line length error
 ## 🔄 **Next Steps**
 
 1. **Commit the updated configuration:**
+
    ```bash
    git add .deepsource.toml
    git commit -m "Fix DeepSource line length configuration to 100 characters"
    ```
 
 2. **Reformat your codebase:**
+
    ```bash
    black .
    ruff check . --fix

--- a/LINE_LENGTH_GUIDE.md
+++ b/LINE_LENGTH_GUIDE.md
@@ -1,0 +1,189 @@
+# Line Length Configuration Guide
+
+## 🎯 **Recommended Line Length: 100 Characters**
+
+Your project is now configured for **100 characters**, which is the modern Python standard that balances readability with practical coding needs.
+
+## 📏 **Line Length Standards Comparison**
+
+| Standard | Length | Used By | Pros | Cons |
+|----------|--------|---------|------|------|
+| **PEP 8 Classic** | 79 | Old Python projects | Maximum compatibility | Too restrictive for modern screens |
+| **Black Default** | 88 | Many modern projects | Good balance | Slightly cramped |
+| **Modern Standard** | 100 | Your project, Django, FastAPI | Practical for today's screens | May not fit on small terminals |
+| **Liberal** | 120+ | Some teams | Very spacious | Can encourage overly complex lines |
+
+## ✅ **Why 100 Characters is Recommended**
+
+### **Modern Development Reality:**
+- **Screen sizes:** Most developers have wide monitors
+- **Code review tools:** GitHub, GitLab handle 100+ characters well
+- **IDE support:** Modern editors handle longer lines effectively
+- **Team productivity:** Less time spent on artificial line breaks
+
+### **Popular Projects Using 100+ Characters:**
+- **Django:** 119 characters
+- **FastAPI:** 100 characters
+- **Pandas:** 100 characters
+- **Many Google projects:** 100 characters
+
+## 🔧 **Current Project Configuration**
+
+### **DeepSource (`.deepsource.toml`)**
+```toml
+[[analyzers]]
+name = "python"
+  [analyzers.meta]
+  runtime_version = "3.11"
+  max_line_length = 100
+```
+
+### **Black (`.pyproject.toml`)**
+```toml
+[tool.black]
+line-length = 100
+target-version = ['py312']
+```
+
+### **Ruff (`.pyproject.toml`)**
+```toml
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+```
+
+### **Prettier (`.prettierrc.json`)**
+```json
+{
+  "printWidth": 100
+}
+```
+
+## 🚀 **Implementation Status**
+
+### **✅ Fixed Issues:**
+1. **DeepSource Configuration:** Updated to use 100 characters instead of 79
+2. **Transformer Conflicts:** Removed conflicting formatters (yapf, autopep8)
+3. **Runtime Version:** Set to Python 3.11 to match your environment
+4. **Consistency:** All tools now use the same line length
+
+### **🔄 Before/After Comparison:**
+
+**Before (Causing Errors):**
+- DeepSource: 79 characters (default)
+- Black: 100 characters
+- Ruff: 100 characters
+- **Result:** Constant line length violations
+
+**After (Consistent):**
+- DeepSource: 100 characters ✅
+- Black: 100 characters ✅
+- Ruff: 100 characters ✅
+- **Result:** No more line length conflicts
+
+## 🛠️ **Alternative Configurations**
+
+### **If You Want 88 Characters (Black Default):**
+```toml
+# In pyproject.toml
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+
+# In .deepsource.toml
+[analyzers.meta]
+max_line_length = 88
+```
+
+### **If You Must Use 79 Characters:**
+```toml
+# In pyproject.toml
+[tool.black]
+line-length = 79
+
+[tool.ruff]
+line-length = 79
+
+# In .deepsource.toml - remove max_line_length (uses default 79)
+```
+
+## 📝 **Best Practices**
+
+### **When to Break Lines (Even with 100 character limit):**
+
+1. **Function signatures with many parameters:**
+   ```python
+   def complex_function(
+       param1: str,
+       param2: int,
+       param3: Optional[Dict[str, Any]] = None,
+   ) -> Tuple[str, int]:
+   ```
+
+2. **Long import statements:**
+   ```python
+   from some.very.long.module.name import (
+       first_function,
+       second_function,
+       third_function,
+   )
+   ```
+
+3. **Complex expressions:**
+   ```python
+   result = (
+       some_long_variable_name
+       + another_long_variable_name
+       + yet_another_variable
+   )
+   ```
+
+### **Tools to Help:**
+
+1. **Black:** Automatically formats to 100 characters
+   ```bash
+   black .
+   ```
+
+2. **Ruff:** Checks and fixes line length issues
+   ```bash
+   ruff check . --fix
+   ```
+
+3. **VS Code:** Set ruler at 100 characters
+   ```json
+   {
+     "editor.rulers": [100]
+   }
+   ```
+
+## 🎉 **Result**
+
+Your DeepSource analysis should now show **significantly fewer line length errors**. The configuration is consistent across all your formatting tools:
+
+- ✅ **Black** will format to 100 characters
+- ✅ **Ruff** will allow up to 100 characters
+- ✅ **DeepSource** will accept up to 100 characters
+- ✅ **Prettier** will format JavaScript/TypeScript to 100 characters
+
+## 🔄 **Next Steps**
+
+1. **Commit the updated configuration:**
+   ```bash
+   git add .deepsource.toml
+   git commit -m "Fix DeepSource line length configuration to 100 characters"
+   ```
+
+2. **Reformat your codebase:**
+   ```bash
+   black .
+   ruff check . --fix
+   ```
+
+3. **Push and check DeepSource dashboard:**
+   - Your line length errors should be dramatically reduced
+   - Only actual code quality issues will remain
+
+You're now using a modern, practical line length standard that works well for contemporary Python development!

--- a/VS_CODE_PYTHON_FIX.md
+++ b/VS_CODE_PYTHON_FIX.md
@@ -83,3 +83,4 @@ If you still see conda activation attempts:
 - The workspace file includes all your existing formatting preferences
 - All your development tools (black, ruff, prettier, eslint) are properly configured
 - The `.venv` virtual environment remains untouched and fully functional
+```


### PR DESCRIPTION
This pull request updates the project's line length configuration to use a modern 100-character standard across all formatting and analysis tools, ensuring consistency and reducing formatting conflicts. It also removes redundant formatters from DeepSource and documents the rationale and configuration details for team reference.

**Configuration consistency and modernization:**

* Updated `.deepsource.toml` to set `max_line_length` to 100 and `runtime_version` to Python 3.11 for the Python analyzer, aligning it with other tools and modern standards.
* Removed conflicting formatters (`yapf`, `autopep8`, `standardjs`) from `.deepsource.toml` to avoid overlapping formatting rules and streamline code style enforcement.

**Documentation and guidance:**

* Added `LINE_LENGTH_GUIDE.md` with a comprehensive explanation of line length standards, rationale for the 100-character limit, configuration examples for all tools, and best practices for line breaking and formatting.

**Minor documentation fix:**

* Added a missing code block closure in `VS_CODE_PYTHON_FIX.md`.