### PR TITLE
Potential fix for code scanning alert no. 44: Uncontrolled data used in path expression

### DIFF
--- a/database/initialize_db.py
+++ b/database/initialize_db.py
@@ -508,19 +508,19 @@ def _get_default_user_data_directory() -> Path:
         user_home = Path.home().resolve()
         default_xdg = Path(os.path.expanduser("~/.local/share")).expanduser().resolve()
         if xdg_env_path:
-            # Normalize BEFORE Path object creation; avoid dangerous expansion
+            # Normalize and validate as string BEFORE Path object creation
             expanded_env_path = os.path.expanduser(xdg_env_path)
             norm_env_path = os.path.normpath(expanded_env_path)
+            abs_env_path = os.path.abspath(norm_env_path)
             try:
-                candidate = Path(norm_env_path).resolve()
-                # Accept only if candidate is strictly inside user_home
-                is_within = getattr(candidate, "is_relative_to", None)
-                if is_within:
-                    safe_env = candidate.is_relative_to(user_home)
-                else:
-                    # Manual check for < 3.9
-                    safe_env = str(candidate).startswith(str(user_home) + os.sep)
+                # Accept only if abs_env_path is strictly inside user_home
+                user_home_str = str(user_home)
+                # Make sure user_home_str ends with os.sep for safe prefix check
+                if not user_home_str.endswith(os.sep):
+                    user_home_str += os.sep
+                safe_env = abs_env_path.startswith(user_home_str)
                 if safe_env:
+                    candidate = Path(abs_env_path).resolve()
                     root_dir = candidate
                 else:
                     logging.warning(

--- a/database/initialize_db.py
+++ b/database/initialize_db.py
@@ -508,10 +508,12 @@ def _get_default_user_data_directory() -> Path:
         user_home = Path.home().resolve()
         default_xdg = Path(os.path.expanduser("~/.local/share")).expanduser().resolve()
         if xdg_env_path:
-            candidate = Path(os.path.expanduser(xdg_env_path)).expanduser().resolve()
-            # Accept only if candidate is strictly inside user_home
+            # Normalize BEFORE Path object creation; avoid dangerous expansion
+            expanded_env_path = os.path.expanduser(xdg_env_path)
+            norm_env_path = os.path.normpath(expanded_env_path)
             try:
-                # Python 3.9+: use is_relative_to
+                candidate = Path(norm_env_path).resolve()
+                # Accept only if candidate is strictly inside user_home
                 is_within = getattr(candidate, "is_relative_to", None)
                 if is_within:
                     safe_env = candidate.is_relative_to(user_home)


### PR DESCRIPTION
Potential fix for [https://github.com/dinoopitstudios/DinoAir/security/code-scanning/44](https://github.com/dinoopitstudios/DinoAir/security/code-scanning/44)

The best way to fix this problem is to ensure that any user-controlled data used in path construction is validated against strong criteria **before** being used to construct a high-privilege path. In this code, we can first normalize the user-provided value, construct the path in a temporary variable, then validate that it is within the user's home (using `.resolve()` or `.normpath` and string comparison or `is_relative_to` when available). Only after passing validation should it be assigned to `candidate` and used for anything else. This means moving the user input usage/extraction and normalization *before* any usage (such as passing into `Path`). The main region to change is the logic around lines 511-512: extract, normalize, and validate, then use only safe results for further operations.

Required:
- Code changes in the region of lines 511–532 in file database/initialize_db.py.
- No special new methods are needed, only ensuring normalization and validation are performed before assignment/usage.
- No new imports required as path validation methods are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
