### PR TITLE
Potential fix for code scanning alert no. 151: Non-exception in 'except' clause

### DIFF
--- a/utils/network_security.py
+++ b/utils/network_security.py
@@ -27,7 +27,8 @@ try:
     from starlette.responses import Response
 except ImportError:
     # Graceful fallback for testing without FastAPI
-    Request = HTTPException = status = JSONResponse = None
+    Request = status = JSONResponse = None
+    HTTPException = Exception
     BaseHTTPMiddleware = RequestResponseEndpoint = Response = object
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/dinoopitstudios/DinoAir/security/code-scanning/151](https://github.com/dinoopitstudios/DinoAir/security/code-scanning/151)

The best solution is to ensure that an invalid `except` clause (with `HTTPException` as `None`) never occurs. This can be done in one of two ways:

1. Change the import fallback so that `HTTPException` is set to a valid exception class (such as `Exception`) instead of `None`.  
2. Conditionally guard or remove the `except HTTPException` handler if `HTTPException` is `None`.

Of these, the least intrusive and most robust fix that maintains the code structure is option 1:  
Edit the fallback in the `except ImportError` block (lines 30-31), assigning `HTTPException = Exception` (or a custom exception defined locally), rather than `None`. This ensures the handler always operates on a valid exception class, preserving the code's intent and function in all environments.

**Where to change:**  
- In `utils/network_security.py`, lines 30-31.  
- Change `HTTPException = ... = None` to `HTTPException = Exception`, with the remaining assignments unchanged.

**What is needed:**  
- A one-line modification to assign `HTTPException = Exception` where fastapi is unavailable.  
- No new imports; `Exception` is built-in and needs no import.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
