### PR TITLE
Potential fix for code scanning alert no. 351: Clear-text logging of sensitive information

### DIFF
--- a/security_summary.py
+++ b/security_summary.py
@@ -166,7 +166,7 @@ def generate_security_summary():
     if code_analysis.get("by_severity", {}).get("error", 0) > 0:
         print(f"   1. Fix {code_analysis['by_severity']['error']} high-priority CodeQL errors")
     if secret_analysis.get("total", 0) > 0:
-        print(f"   2. Address {secret_analysis['total']} exposed secrets immediately")
+        print("   2. Address all exposed secrets immediately")
     if dependabot_analysis.get("total", 0) > 0:
         print(f"   3. Update {dependabot_analysis['total']} vulnerable dependencies")
     if total_issues == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/dinoopitstudios/DinoAir/security/code-scanning/351](https://github.com/dinoopitstudios/DinoAir/security/code-scanning/351)

To fix the problem, we should avoid logging the exact count of detected secrets in contexts where it could lead to sensitive information disclosure, especially in summary messages or recommendation sections. In practical terms, this means updating line 169 in `generate_security_summary` so it does not print the count of exposed secrets directly, and instead prints a generic warning or recommendation that exposed secrets have been detected and need to be addressed, without quantifying them.

Specifically, in the file `security_summary.py`, modify the print statement at line 169 so that it does not interpolate `secret_analysis['total']`. Instead, simply issue a general message such as `"2. Address all exposed secrets immediately"`. No new imports or definition changes are necessary; just a print string update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
